### PR TITLE
Fix dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ dnspython==1.16.0
 email-validator==1.1.1
 Flask==1.1.2
 Flask-Alembic==2.0.1
-git+https://github.com/justanr/flask-allows.git@f/Cut-down-on-warnings#egg=flask-allows
+flask-allows
 Flask-BabelPlus==2.2.0
 Flask-Caching==1.9.0
 Flask-DebugToolbar==0.11.0
@@ -28,6 +28,7 @@ flask-whooshee==0.7.0
 Flask-WTF==0.14.3
 flaskbb-plugin-conversations==1.0.7
 flaskbb-plugin-portal==1.1.3
+flask_discord
 future==0.18.2
 idna==2.10
 itsdangerous==1.1.0
@@ -38,7 +39,7 @@ Mako==1.1.3
 MarkupSafe==1.1.1
 mistune==0.8.4
 olefile==0.46
-Pillow==7.2.0
+Pillow
 pluggy==0.13.1
 Pygments==2.6.1
 python-dateutil==2.8.1


### PR DESCRIPTION
Pillow 7.2.0 ругается на питон 3.9
flask_allow вообще не устанавливался
flask_discord требуется но в зависимостях отсутствовал