### PR TITLE
fix(db): fix incorrect migration scripts

### DIFF
--- a/migrations/202011120431_3578b2224265_merge_heads.py
+++ b/migrations/202011120431_3578b2224265_merge_heads.py
@@ -11,7 +11,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = '3578b2224265'
-down_revision = ('7dc4f95f6ee1', '0625bc75ab77')
+down_revision = ('7dc4f95f6ee1')
 branch_labels = ()
 depends_on = None
 


### PR DESCRIPTION
При выполнений команды `make install` алембик падает с ошибкой
`Revision 0625bc75ab77 referenced from 7dc4f95f6ee1, 0625bc75ab77 -> 3578b2224265 (mergepoint), merge heads is not present`
`KeyError: '0625bc75ab77'`
Какой-то из скриптов миграции похоже внезапно сломался. Удалил все что-бы такая хрень не повторилась.